### PR TITLE
Fix to use same locale C.UTF-8

### DIFF
--- a/Software/zero2go/zero2go.sh
+++ b/Software/zero2go/zero2go.sh
@@ -2,6 +2,9 @@
 # file: zero2go.sh
 #
 
+#use single locale
+LC_ALL=C.UTF-8
+
 # include utilities script in same directory
 my_dir="`dirname \"$0\"`"
 my_dir="`( cd \"$my_dir\" && pwd )`"


### PR DESCRIPTION
In other locales (ex. es_CL.UTF-8), the voltages aren't printed because decimal point is represent with ',' and not '.' as expected.
This correct the problem.